### PR TITLE
Doc CRUD tests with API hooks [dev/68-crud-doc-tests]

### DIFF
--- a/api-utils/apiHooks.ts
+++ b/api-utils/apiHooks.ts
@@ -57,4 +57,20 @@ export class ApiHooks {
 
     await request.delete(deleteTaskEndpoint, { headers: { Authorization: apiKey, "Content-Type": "application/json" } });
   }
+
+  public static async createNewDocInSpace(request: APIRequestContext, docName: string, spaceId: string) {
+    const teamId: string = process.env.BASE_TEAM_ID as string;
+    const apiKey: string = process.env.API_KEY as string;
+    const createDocEndpoint: string = `https://api.clickup.com/api/v3/workspaces/${teamId}/docs`;
+
+    const newDocBody = {
+      name: docName,
+      parent: {
+        id: spaceId,
+        type: 4,
+      },
+    };
+
+    await request.post(createDocEndpoint, { headers: { Authorization: apiKey }, data: newDocBody });
+  }
 }

--- a/api-utils/apiHooks.ts
+++ b/api-utils/apiHooks.ts
@@ -1,5 +1,6 @@
 import { APIRequestContext, APIResponse } from "@playwright/test";
 import { ApiUtils } from "./apiUtils";
+import session from "../playwright/.auth/user-session.json"
 
 export class ApiHooks {
   public static async deleteSpaceByName(request: APIRequestContext, spaceName: string) {
@@ -72,5 +73,16 @@ export class ApiHooks {
     };
 
     await request.post(createDocEndpoint, { headers: { Authorization: apiKey }, data: newDocBody });
+  }
+
+  public static async deleteDocsByName(request: APIRequestContext, docName: string) {
+    const token: string = session.origins[0].localStorage.filter(element => element.name == "id_token")[0].value
+    const deleteDocsEndpoint = "https://prod-eu-west-1-3.clickup.com/viz/v1/view"
+
+    const body = {
+      "viewIds": await ApiUtils.getDocIdsByName(request, docName)
+    }
+
+    await request.delete(deleteDocsEndpoint, { headers: { Authorization: `Bearer ${token}` }, data: body })
   }
 }

--- a/api-utils/apiUtils.ts
+++ b/api-utils/apiUtils.ts
@@ -77,4 +77,23 @@ export class ApiUtils {
     const baseListName: string = "Project 1";
     return await this.getListIdByName(request, baseSpaceName, baseFolderName, baseListName);
   }
+
+  /**
+   * Api function for getting id strings of all docs with given name
+   * @param request Typical `request` object taken from Playwright
+   * @param docName Name of doc (or docs), which will be deleted, eq. "*Practical Fresh Fish*"
+   * @returns Array of IDs of docs with given name, eq. `["8cnhpru-2975", "8cnhpru-3055", "8cnhpru-3095"]`
+   */
+  @apiTryCatch("Doc")
+  public static async getDocIdsByName(request: APIRequestContext, docName: string) {
+    const apiKey: string = process.env.API_KEY as string;
+    const teamId: string = process.env.BASE_TEAM_ID as string;
+    const getAllDocsEndpoint: string = `https://api.clickup.com/api/v3/workspaces/${teamId}/docs`;
+
+    const getAllDOcsResponse: APIResponse = await request.get(getAllDocsEndpoint, { headers: { Authorization: apiKey } });
+    const docsArray = (await getAllDOcsResponse.json()).docs.filter((doc) => doc.name === docName);
+    const docsId: string[] = docsArray.map(doc => doc.id)
+
+    return docsId;
+  }
 }

--- a/page-objects/context-menus/docContextMenu.ts
+++ b/page-objects/context-menus/docContextMenu.ts
@@ -1,0 +1,20 @@
+import { Locator, Page } from "@playwright/test";
+import { logClicking } from "../../utils/decorators";
+
+export class DocContextMenu {
+  private readonly page: Page;
+  private readonly menuContainer: Locator;
+
+  private menuOption: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.menuContainer = this.page.getByTestId("dropdown__menu__sidebar");
+  }
+
+  @logClicking("context menu option")
+  async clickOnOption(optionName: string) {
+    this.menuOption = this.menuContainer.getByRole("button", { name: optionName });
+    await this.menuOption.click();
+  }
+}

--- a/page-objects/context-menus/spacePlusMenu.ts
+++ b/page-objects/context-menus/spacePlusMenu.ts
@@ -1,0 +1,20 @@
+import { Locator, Page } from "@playwright/test";
+import { logClicking } from "../../utils/decorators";
+
+export class SpacePlusMenu {
+  private readonly page: Page;
+  private readonly menuContainer: Locator;
+
+  private menuOption: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.menuContainer = this.page.locator("cu-nav-menu-create-new").first();
+  }
+
+  @logClicking("menu option")
+  async clickOnOption(optionName: string) {
+    this.menuOption = this.menuContainer.getByRole("button", { name: optionName });
+    await this.menuOption.click();
+  }
+}

--- a/page-objects/docView.ts
+++ b/page-objects/docView.ts
@@ -1,0 +1,26 @@
+import { Locator, Page } from "@playwright/test";
+import { logClicking, logTyping } from "../utils/decorators";
+
+export class DocView {
+  private readonly page: Page;
+  private readonly mainView: Locator;
+  private readonly docTitleInput: Locator;
+  private readonly docTitleEditableInput: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.mainView = this.page.getByTestId("dashboard-doc-main__container");
+    this.docTitleInput = this.mainView.getByTestId("dashboard-doc-title__doc-title-text__");
+    this.docTitleEditableInput = this.mainView.getByTestId("editable__input");
+  }
+
+  @logTyping("Doc title")
+  async typeDocTitle(newDocTitle: string) {
+    await this.docTitleEditableInput.fill(newDocTitle);
+  }
+
+  @logClicking("'Enter' keyboard key")
+  async clickKeyBoardKey(keyboardKey: string) {
+    await this.docTitleEditableInput.press(keyboardKey);
+  }
+}

--- a/page-objects/docView.ts
+++ b/page-objects/docView.ts
@@ -19,7 +19,7 @@ export class DocView {
     await this.docTitleEditableInput.fill(newDocTitle);
   }
 
-  @logClicking("'Enter' keyboard key")
+  @logClicking("keyboard key")
   async clickKeyBoardKey(keyboardKey: string) {
     await this.docTitleEditableInput.press(keyboardKey);
   }

--- a/page-objects/leftMenu.ts
+++ b/page-objects/leftMenu.ts
@@ -11,7 +11,7 @@ export class LeftMenu {
   constructor(page: Page) {
     this.page = page;
     this.leftSideBar = this.page.locator("cu-simple-bar");
-    this.renameInput = this.leftSideBar.getByTestId("nav-editor__input")
+    this.renameInput = this.leftSideBar.getByTestId("nav-editor__input");
   }
 
   @logClicking("left menu option")
@@ -39,6 +39,11 @@ export class LeftMenu {
   async assertElementIsVisible(elementName: string) {
     this.menuElement = this.leftSideBar.getByRole("treeitem", { name: elementName });
     await expect(this.menuElement).toBeVisible();
+  }
+
+  async assertElementsAreVisible(elementsName: string, elementsNumber: number) {
+    this.menuElement = this.leftSideBar.getByRole("treeitem", { name: elementsName });
+    await expect(this.menuElement).toHaveCount(elementsNumber);
   }
 
   async assertElementIsNotVisible(elementName: string) {

--- a/page-objects/leftMenu.ts
+++ b/page-objects/leftMenu.ts
@@ -1,15 +1,17 @@
 import { Locator, Page, expect } from "@playwright/test";
-import { logClicking } from "../utils/decorators";
+import { logClicking, logTyping } from "../utils/decorators";
 
 export class LeftMenu {
   private readonly page: Page;
   private readonly leftSideBar: Locator;
+  private readonly renameInput: Locator;
 
   private menuElement: Locator;
 
   constructor(page: Page) {
     this.page = page;
     this.leftSideBar = this.page.locator("cu-simple-bar");
+    this.renameInput = this.leftSideBar.getByTestId("nav-editor__input")
   }
 
   @logClicking("left menu option")
@@ -22,6 +24,16 @@ export class LeftMenu {
   async rightClickOnElement(elementName: string) {
     this.menuElement = this.leftSideBar.getByRole("treeitem", { name: elementName });
     await this.menuElement.click({ button: "right" });
+  }
+
+  @logTyping("Rename doc")
+  async typeIntoRenameDocInput(newDocName: string) {
+    await this.renameInput.fill(newDocName);
+  }
+
+  @logClicking("keyboard key")
+  async clickKeyBoardKey(keyboardKey: string) {
+    await this.leftSideBar.press(keyboardKey);
   }
 
   async assertElementIsVisible(elementName: string) {

--- a/tests/docBasicTests.spec.ts
+++ b/tests/docBasicTests.spec.ts
@@ -23,6 +23,10 @@ test.describe(
       await ApiHooks.createSpaceByName(request, newSpaceName);
     });
 
+    test.afterEach("Prepare environment before tests", async ({ request }) => {
+      await ApiHooks.deleteSpaceByName(request, newSpaceName);
+    });
+
     test(
       "Basic test for creating new doc in existing space",
       {

--- a/tests/docBasicTests.spec.ts
+++ b/tests/docBasicTests.spec.ts
@@ -59,7 +59,6 @@ test.describe(
     test(
       "Basic test for deleting existing doc in existing space",
       {
-        tag: "@this", // FIXME remove before committing
         annotation: {
           type: "issue",
           description: "https://github.com/marian51/poc-playwright-typescript-gui-api/issues/68",
@@ -81,5 +80,30 @@ test.describe(
         await leftMenu.assertElementIsNotVisible(newDocName);
       }
     );
+
+    test(
+      "@this Basic test for duplicating existing doc in existing space",
+      {
+        annotation: {
+          type: "issue",
+          description: "https://github.com/marian51/poc-playwright-typescript-gui-api/issues/68",
+        },
+      },
+      async ({ page, request }) => {
+        const leftMenu = new LeftMenu(page);
+        const docContextMenu = new DocContextMenu(page);
+
+        await ApiHooks.createNewDocInSpace(request, newDocName, await ApiUtils.getSpaceIdByName(request, newSpaceName));
+
+        await page.goto("/");
+        await page.locator("cu-web-push-notification-banner").waitFor();
+
+        await leftMenu.clickOnElement(newSpaceName);
+        await leftMenu.rightClickOnElement(newDocName);
+        await docContextMenu.clickOnOption("Duplicate");
+
+        await leftMenu.assertElementIsVisible(newDocName + " (copy)");
+      }
+    )
   }
 );

--- a/tests/docBasicTests.spec.ts
+++ b/tests/docBasicTests.spec.ts
@@ -5,9 +5,11 @@ import { SpacePlusMenu } from "../page-objects/context-menus/spacePlusMenu";
 import { ApiHooks } from "../api-utils/apiHooks";
 import { DocView } from "../page-objects/docView";
 import { faker } from "@faker-js/faker";
+import { ApiUtils } from "../api-utils/apiUtils";
+import { DocContextMenu } from "../page-objects/context-menus/docContextMenu";
 
 test.describe(
-  "Basic UI tests for checking base doc functionalities",
+  "UI tests for checking basic doc functionalities",
   {
     tag: ["@doc", "@one"],
     annotation: {
@@ -51,6 +53,32 @@ test.describe(
         await docView.clickKeyBoardKey("Enter");
 
         await leftMenu.assertElementIsVisible(newDocName);
+      }
+    );
+
+    test(
+      "Basic test for deleting existing doc in existing space",
+      {
+        tag: "@this", // FIXME remove before committing
+        annotation: {
+          type: "issue",
+          description: "https://github.com/marian51/poc-playwright-typescript-gui-api/issues/68",
+        },
+      },
+      async ({ page, request }) => {
+        const leftMenu = new LeftMenu(page);
+        const docContextMenu = new DocContextMenu(page);
+
+        await ApiHooks.createNewDocInSpace(request, newDocName, await ApiUtils.getSpaceIdByName(request, newSpaceName));
+
+        await page.goto("/");
+        await page.locator("cu-web-push-notification-banner").waitFor();
+
+        await leftMenu.clickOnElement(newSpaceName);
+        await leftMenu.rightClickOnElement(newDocName);
+        await docContextMenu.clickOnOption("Delete");
+
+        await leftMenu.assertElementIsNotVisible(newDocName);
       }
     );
   }

--- a/tests/docBasicTests.spec.ts
+++ b/tests/docBasicTests.spec.ts
@@ -21,11 +21,11 @@ test.describe(
     const newSpaceName = "GUI TEST new space";
     const newDocName = faker.commerce.productName();
 
-    test.beforeEach("Prepare environment before tests", async ({ request }) => {
+    test.beforeAll("Prepare environment before tests", async ({ request }) => {
       await ApiHooks.createSpaceByName(request, newSpaceName);
     });
 
-    test.afterEach("Prepare environment before tests", async ({ request }) => {
+    test.afterAll("Prepare environment before tests", async ({ request }) => {
       await ApiHooks.deleteSpaceByName(request, newSpaceName);
     });
 
@@ -37,7 +37,7 @@ test.describe(
           description: "https://github.com/marian51/poc-playwright-typescript-gui-api/issues/68",
         },
       },
-      async ({ page }) => {
+      async ({ page, request }) => {
         const leftMenu = new LeftMenu(page);
         const spaceContextMenu = new SpaceContextMenu(page);
         const spacePlusMenu = new SpacePlusMenu(page);
@@ -53,6 +53,8 @@ test.describe(
         await docView.clickKeyBoardKey("Enter");
 
         await leftMenu.assertElementIsVisible(newDocName);
+
+        await ApiHooks.deleteDocsByName(request, newDocName);
       }
     );
 
@@ -103,9 +105,11 @@ test.describe(
         await leftMenu.rightClickOnElement(newDocName);
         await docContextMenu.clickOnOption("Rename");
         await leftMenu.typeIntoRenameDocInput(renamedDocName);
-        await leftMenu.clickKeyBoardKey("Enter")
+        await leftMenu.clickKeyBoardKey("Enter");
 
         await leftMenu.assertElementIsVisible(renamedDocName);
+
+        await ApiHooks.deleteDocsByName(request, renamedDocName);
       }
     );
 
@@ -128,15 +132,17 @@ test.describe(
         await page.locator("cu-web-push-notification-banner").waitFor();
 
         await leftMenu.clickOnElement(newSpaceName);
-        await page.getByRole("button", {name: "Add List"}).waitFor()
+        await page.getByRole("button", { name: "Add List" }).waitFor();
         await leftMenu.clickOnElement(newDocName);
         await docView.typeDocTitle(renamedDocTitle);
         await docView.clickKeyBoardKey("Enter");
 
         await leftMenu.assertElementIsVisible(renamedDocTitle);
         await leftMenu.assertElementIsNotVisible(newDocName);
+
+        await ApiHooks.deleteDocsByName(request, renamedDocTitle);
       }
-    )
+    );
 
     test(
       "Basic test for creating new doc with the same name",
@@ -164,8 +170,10 @@ test.describe(
         await docView.clickKeyBoardKey("Enter");
 
         await leftMenu.assertElementsAreVisible(newDocName, 2);
+
+        await ApiHooks.deleteDocsByName(request, newDocName);
       }
-    )
+    );
 
     test(
       "Basic test for duplicating existing doc in existing space",
@@ -189,6 +197,9 @@ test.describe(
         await docContextMenu.clickOnOption("Duplicate");
 
         await leftMenu.assertElementIsVisible(newDocName + " (copy)");
+
+        await ApiHooks.deleteDocsByName(request, newDocName);
+        await ApiHooks.deleteDocsByName(request, newDocName + " (copy)");
       }
     );
   }

--- a/tests/docBasicTests.spec.ts
+++ b/tests/docBasicTests.spec.ts
@@ -82,7 +82,7 @@ test.describe(
     );
 
     test(
-      "@this Basic test for renaming existing doc in existing space",
+      "Basic test for renaming existing doc in existing space",
       {
         annotation: {
           type: "issue",
@@ -108,6 +108,35 @@ test.describe(
         await leftMenu.assertElementIsVisible(renamedDocName);
       }
     );
+
+    test(
+      "Basic test for creating new doc with the same name",
+      {
+        annotation: {
+          type: "issue",
+          description: "https://github.com/marian51/poc-playwright-typescript-gui-api/issues/68",
+        },
+      },
+      async ({ page, request }) => {
+        const leftMenu = new LeftMenu(page);
+        const spaceContextMenu = new SpaceContextMenu(page);
+        const spacePlusMenu = new SpacePlusMenu(page);
+        const docView = new DocView(page);
+
+        await ApiHooks.createNewDocInSpace(request, newDocName, await ApiUtils.getSpaceIdByName(request, newSpaceName));
+
+        await page.goto("/");
+        await page.locator("cu-web-push-notification-banner").waitFor();
+
+        await leftMenu.rightClickOnElement(newSpaceName);
+        await spaceContextMenu.clickOnOption("Create new");
+        await spacePlusMenu.clickOnOption("Doc");
+        await docView.typeDocTitle(newDocName);
+        await docView.clickKeyBoardKey("Enter");
+
+        await leftMenu.assertElementsAreVisible(newDocName, 2);
+      }
+    )
 
     test(
       "Basic test for duplicating existing doc in existing space",

--- a/tests/docBasicTests.spec.ts
+++ b/tests/docBasicTests.spec.ts
@@ -110,6 +110,35 @@ test.describe(
     );
 
     test(
+      "Test for checking if changing doc title changes doc name",
+      {
+        annotation: {
+          type: "issue",
+          description: "https://github.com/marian51/poc-playwright-typescript-gui-api/issues/68",
+        },
+      },
+      async ({ page, request }) => {
+        const leftMenu = new LeftMenu(page);
+        const docView = new DocView(page);
+        const renamedDocTitle = faker.commerce.productName();
+
+        await ApiHooks.createNewDocInSpace(request, newDocName, await ApiUtils.getSpaceIdByName(request, newSpaceName));
+
+        await page.goto("/");
+        await page.locator("cu-web-push-notification-banner").waitFor();
+
+        await leftMenu.clickOnElement(newSpaceName);
+        await page.getByRole("button", {name: "Add List"}).waitFor()
+        await leftMenu.clickOnElement(newDocName);
+        await docView.typeDocTitle(renamedDocTitle);
+        await docView.clickKeyBoardKey("Enter");
+
+        await leftMenu.assertElementIsVisible(renamedDocTitle);
+        await leftMenu.assertElementIsNotVisible(newDocName);
+      }
+    )
+
+    test(
       "Basic test for creating new doc with the same name",
       {
         annotation: {

--- a/tests/docBasicTests.spec.ts
+++ b/tests/docBasicTests.spec.ts
@@ -82,7 +82,35 @@ test.describe(
     );
 
     test(
-      "@this Basic test for duplicating existing doc in existing space",
+      "@this Basic test for renaming existing doc in existing space",
+      {
+        annotation: {
+          type: "issue",
+          description: "https://github.com/marian51/poc-playwright-typescript-gui-api/issues/68",
+        },
+      },
+      async ({ page, request }) => {
+        const leftMenu = new LeftMenu(page);
+        const docContextMenu = new DocContextMenu(page);
+        const renamedDocName = faker.commerce.productName();
+
+        await ApiHooks.createNewDocInSpace(request, newDocName, await ApiUtils.getSpaceIdByName(request, newSpaceName));
+
+        await page.goto("/");
+        await page.locator("cu-web-push-notification-banner").waitFor();
+
+        await leftMenu.clickOnElement(newSpaceName);
+        await leftMenu.rightClickOnElement(newDocName);
+        await docContextMenu.clickOnOption("Rename");
+        await leftMenu.typeIntoRenameDocInput(renamedDocName);
+        await leftMenu.clickKeyBoardKey("Enter")
+
+        await leftMenu.assertElementIsVisible(renamedDocName);
+      }
+    );
+
+    test(
+      "Basic test for duplicating existing doc in existing space",
       {
         annotation: {
           type: "issue",
@@ -104,6 +132,6 @@ test.describe(
 
         await leftMenu.assertElementIsVisible(newDocName + " (copy)");
       }
-    )
+    );
   }
 );

--- a/tests/docBasicTests.spec.ts
+++ b/tests/docBasicTests.spec.ts
@@ -1,0 +1,53 @@
+import test from "@playwright/test";
+import { LeftMenu } from "../page-objects/leftMenu";
+import { SpaceContextMenu } from "../page-objects/context-menus/spaceContextMenu";
+import { SpacePlusMenu } from "../page-objects/context-menus/spacePlusMenu";
+import { ApiHooks } from "../api-utils/apiHooks";
+import { DocView } from "../page-objects/docView";
+import { faker } from "@faker-js/faker";
+
+test.describe(
+  "Basic UI tests for checking base doc functionalities",
+  {
+    tag: ["@doc", "@one"],
+    annotation: {
+      type: "test type",
+      description: "One basic test",
+    },
+  },
+  async () => {
+    const newSpaceName = "GUI TEST new space";
+    const newDocName = faker.commerce.productName();
+
+    test.beforeEach("Prepare environment before tests", async ({ request }) => {
+      await ApiHooks.createSpaceByName(request, newSpaceName);
+    });
+
+    test(
+      "Basic test for creating new doc in existing space",
+      {
+        annotation: {
+          type: "issue",
+          description: "https://github.com/marian51/poc-playwright-typescript-gui-api/issues/68",
+        },
+      },
+      async ({ page }) => {
+        const leftMenu = new LeftMenu(page);
+        const spaceContextMenu = new SpaceContextMenu(page);
+        const spacePlusMenu = new SpacePlusMenu(page);
+        const docView = new DocView(page);
+
+        await page.goto("/");
+        await page.locator("cu-web-push-notification-banner").waitFor();
+
+        await leftMenu.rightClickOnElement(newSpaceName);
+        await spaceContextMenu.clickOnOption("Create new");
+        await spacePlusMenu.clickOnOption("Doc");
+        await docView.typeDocTitle(newDocName);
+        await docView.clickKeyBoardKey("Enter");
+
+        await leftMenu.assertElementIsVisible(newDocName);
+      }
+    );
+  }
+);


### PR DESCRIPTION
- tests:
  - create doc
  - delete doc
  - rename doc (by left side menu)
  - rename doc (by doc title)
  - create doc with the same name
  - duplicate doc
- hooks:
  - hook for creating doc in space by name
  - hook for deleting docs by name
- page objects:
  - Doc context menu
  - Doc main view
  - Space "plus" menu