### PR TITLE
Bypass annoying "Introducing Connected Search" popup [dev/101-byspass-search-popup]

### DIFF
--- a/tests/GUI/docBasicTests.spec.ts
+++ b/tests/GUI/docBasicTests.spec.ts
@@ -7,7 +7,7 @@ import { DocView } from "../../page-objects/docView";
 import { faker } from "@faker-js/faker";
 import { ApiUtils } from "../../api-utils/apiUtils";
 import { DocContextMenu } from "../../page-objects/context-menus/docContextMenu";
-import waitForPageLoad from "../../utils/GlobalGuiUtils";
+import { waitForPageLoad } from "../../utils/GlobalGuiUtils";
 
 test.describe(
   "UI tests for checking basic doc functionalities",

--- a/tests/GUI/folder.spec.ts
+++ b/tests/GUI/folder.spec.ts
@@ -5,7 +5,7 @@ import { FolderContextMenu } from "../../page-objects/context-menus/folderContex
 import { DeleteFolderModal } from "../../page-objects/modals/deleteFolderModal";
 import { ApiHooks } from "../../api-utils/apiHooks";
 import { SpacePlusMenu } from "../../page-objects/context-menus/spacePlusMenu";
-import waitForPageLoad from "../../utils/GlobalGuiUtils";
+import { waitForPageLoad } from "../../utils/GlobalGuiUtils";
 
 test.describe(
   "Folder tests",

--- a/tests/GUI/sortList.spec.ts
+++ b/tests/GUI/sortList.spec.ts
@@ -3,7 +3,7 @@ import { LeftMenu } from "../../page-objects/leftMenu";
 import tasks from "../../resources/tasks-import.json";
 import { ApiHooks } from "../../api-utils/apiHooks";
 import { ProjectMainView } from "../../page-objects/projectMainView";
-import waitForPageLoad from "../../utils/GlobalGuiUtils";
+import { waitForPageLoad } from "../../utils/GlobalGuiUtils";
 
 let leftMenu: LeftMenu;
 let projectMainView: ProjectMainView;

--- a/tests/GUI/spaceBasicTests.spec.ts
+++ b/tests/GUI/spaceBasicTests.spec.ts
@@ -6,7 +6,7 @@ import { DeleteSpaceModal } from "../../page-objects/modals/deleteSpaceModal";
 import { SpaceContextMenu } from "../../page-objects/context-menus/spaceContextMenu";
 import { EditSpaceNameModal } from "../../page-objects/modals/editSpaceNameModal";
 import { DuplicateSpaceModal } from "../../page-objects/modals/duplicateSpaceModal";
-import waitForPageLoad from "../../utils/GlobalGuiUtils";
+import { waitForPageLoad } from "../../utils/GlobalGuiUtils";
 
 test.describe(
   "UI tests for checking basic space functionalities",

--- a/tests/auth.setup.ts
+++ b/tests/auth.setup.ts
@@ -1,5 +1,6 @@
 import { test as setup } from "@playwright/test";
 import { LoginPage } from "../page-objects/loginPage";
+import { disableConnectedSearchPopup } from "../utils/GlobalGuiUtils";
 
 const authFile = "playwright/.auth/user-session.json";
 
@@ -10,6 +11,7 @@ setup("authenticate", async ({ page }) => {
   await page.goto("/login");
   await loginPage.loginAsUser();
   await page.waitForURL(mainPageDynamicUrl);
+  await disableConnectedSearchPopup(page);
 
   await page.context().storageState({ path: authFile });
 });

--- a/utils/GlobalGuiUtils.ts
+++ b/utils/GlobalGuiUtils.ts
@@ -1,6 +1,6 @@
 import { Page } from "@playwright/test";
 
-export default async function waitForPageLoad(page: Page) {
+export async function waitForPageLoad(page: Page) {
   try {
     await page.locator("cu-web-push-notification-banner").waitFor({ timeout: 5000 });
     console.log("Notifications bar has been loaded.");

--- a/utils/GlobalGuiUtils.ts
+++ b/utils/GlobalGuiUtils.ts
@@ -10,3 +10,7 @@ export async function waitForPageLoad(page: Page) {
     console.log("Continuing to run the test.");
   }
 }
+
+export async function disableConnectedSearchPopup(page: Page) {
+  await page.evaluate(() => {localStorage.setItem("slapdash:cu-universal-search-modal-dismissed", "true");})
+}


### PR DESCRIPTION
Po zalogowaniu się na ClickUpa w nowej instancji przeglądarki (np. incognito czy podczas wykonywania testów) pojawia się irytujące okienko "Introducing Connected Search" oferujące jakieś tam płatne wyszukiwanie. 
![image](https://github.com/user-attachments/assets/13eccc7a-f02f-4ece-82aa-04c40e4f4c51)
Okienko to może hamować wykonywanie testów. Kliknięcie "Skip" niewiele da, bo po ponownym otwarciu przeglądarki okienko pojawi się ponownie. Kliknięcie "Explore" i poczekanie kilku sekund generalnie załatwia sprawę - okienko nie pojawi się po ponownym włączeniu przeglądarki. Ale można też wrzucić do localStorage wpis, który potwierdza "dismiss" tego okienka, co jest szybsze niż klikanie i czekanie. Dorzuciłem do do momentu logowania. Kolejne testy korzystają z tego localStorage, więc okienko się nie pojawia.